### PR TITLE
Fix build on macOS.

### DIFF
--- a/compat/jansson-2.9/jansson_private_config.h.in
+++ b/compat/jansson-2.9/jansson_private_config.h.in
@@ -30,7 +30,7 @@
 /* Define to 1 if you have the <locale.h> header file. */
 #undef HAVE_LOCALE_H
 
-/* Define to 1 if the system has the type 'long long int'. */
+/* Define to 1 if the system has the type `long long int'. */
 #undef HAVE_LONG_LONG_INT
 
 /* Define to 1 if you have the <memory.h> header file. */
@@ -81,7 +81,7 @@
 /* Define to 1 if you have the <unistd.h> header file. */
 #undef HAVE_UNISTD_H
 
-/* Define to 1 if the system has the type 'unsigned long long int'. */
+/* Define to 1 if the system has the type `unsigned long long int'. */
 #undef HAVE_UNSIGNED_LONG_LONG_INT
 
 /* Number of buckets new object hashtables contain is 2 raised to this power.

--- a/compat/jansson-2.9/test-driver
+++ b/compat/jansson-2.9/test-driver
@@ -1,9 +1,9 @@
 #! /bin/sh
 # test-driver - basic testsuite driver script.
 
-scriptversion=2013-07-13.22; # UTC
+scriptversion=2018-03-07.03; # UTC
 
-# Copyright (C) 2011-2014 Free Software Foundation, Inc.
+# Copyright (C) 2011-2018 Free Software Foundation, Inc.
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -16,7 +16,7 @@ scriptversion=2013-07-13.22; # UTC
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 # As a special exception to the GNU General Public License, if you
 # distribute this file as part of a program that contains a
@@ -140,9 +140,9 @@ echo ":copy-in-global-log: $gcopy" >> $trs_file
 # Local Variables:
 # mode: shell-script
 # sh-indentation: 2
-# eval: (add-hook 'write-file-hooks 'time-stamp)
+# eval: (add-hook 'before-save-hook 'time-stamp)
 # time-stamp-start: "scriptversion="
 # time-stamp-format: "%:y-%02m-%02d.%02H"
-# time-stamp-time-zone: "UTC"
+# time-stamp-time-zone: "UTC0"
 # time-stamp-end: "; # UTC"
 # End:

--- a/util.c
+++ b/util.c
@@ -1495,22 +1495,26 @@ static void nanosleep_abstime(struct timespec *ts_end)
  * from the beginning of the actual sleep, allowing scheduling delays to be
  * counted in the sleep. */
 #ifdef USE_BITMAIN_SOC
-void cgsleep_ms_r(cgtimer_t *ts_start, int ms)
+int cgsleep_ms_r(cgtimer_t *ts_start, int ms)
 {
 	struct timespec ts_end;
 
 	ms_to_timespec(&ts_end, ms);
 	timeraddspec(&ts_end, ts_start);
 	nanosleep_abstime(&ts_end);
+
+        return 0;
 }
 
-void cgsleep_us_r(cgtimer_t *ts_start, int64_t us)
+int64_t cgsleep_us_r(cgtimer_t *ts_start, int64_t us)
 {
 	struct timespec ts_end;
 
 	us_to_timespec(&ts_end, us);
 	timeraddspec(&ts_end, ts_start);
 	nanosleep_abstime(&ts_end);
+
+        return 0;
 }
 #else /* USE_BITMAIN_SOC */
 int cgsleep_ms_r(cgtimer_t *ts_start, int ms)
@@ -1622,15 +1626,17 @@ static void liSleep(LARGE_INTEGER *li, int timeout)
 	CloseHandle(hTimer);
 }
 
-void cgsleep_ms_r(cgtimer_t *ts_start, int ms)
+int cgsleep_ms_r(cgtimer_t *ts_start, int ms)
 {
 	LARGE_INTEGER li;
 
 	li.QuadPart = ts_start->QuadPart + (int64_t)ms * 10000LL;
 	liSleep(&li, ms);
+
+        return 0;
 }
 
-void cgsleep_us_r(cgtimer_t *ts_start, int64_t us)
+int64_t cgsleep_us_r(cgtimer_t *ts_start, int64_t us)
 {
 	LARGE_INTEGER li;
 	int ms;
@@ -1640,6 +1646,8 @@ void cgsleep_us_r(cgtimer_t *ts_start, int64_t us)
 	if (!ms)
 		ms = 1;
 	liSleep(&li, ms);
+
+        return 0;
 }
 #else /* WIN32 */
 static void cgsleep_spec(struct timespec *ts_diff, const struct timespec *ts_start)
@@ -1654,20 +1662,24 @@ static void cgsleep_spec(struct timespec *ts_diff, const struct timespec *ts_sta
 	nanosleep(ts_diff, NULL);
 }
 
-void cgsleep_ms_r(cgtimer_t *ts_start, int ms)
+int cgsleep_ms_r(cgtimer_t *ts_start, int ms)
 {
 	struct timespec ts_diff;
 
 	ms_to_timespec(&ts_diff, ms);
 	cgsleep_spec(&ts_diff, ts_start);
+
+        return 0;
 }
 
-void cgsleep_us_r(cgtimer_t *ts_start, int64_t us)
+int64_t cgsleep_us_r(cgtimer_t *ts_start, int64_t us)
 {
 	struct timespec ts_diff;
 
 	us_to_timespec(&ts_diff, us);
 	cgsleep_spec(&ts_diff, ts_start);
+
+        return 0;
 }
 #endif /* WIN32 */
 #endif /* CLOCK_MONOTONIC */

--- a/util.h
+++ b/util.h
@@ -140,13 +140,8 @@ void cgsleep_ms(int ms);
 void cgsleep_us(int64_t us);
 void cgtimer_time(cgtimer_t *ts_start);
 #define cgsleep_prepare_r(ts_start) cgtimer_time(ts_start)
-#ifdef USE_BITMAIN_SOC
-void cgsleep_ms_r(cgtimer_t *ts_start, int ms);
-void cgsleep_us_r(cgtimer_t *ts_start, int64_t us);
-#else
 int cgsleep_ms_r(cgtimer_t *ts_start, int ms);
 int64_t cgsleep_us_r(cgtimer_t *ts_start, int64_t us);
-#endif
 int cgtimer_to_ms(cgtimer_t *cgt);
 void cgtimer_sub(cgtimer_t *a, cgtimer_t *b, cgtimer_t *res);
 double us_tdiff(struct timeval *end, struct timeval *start);


### PR DESCRIPTION
The prototypes for `cgsleep_ms_r` and `cgsleep_us_r` didn't match the
implementation, and have been updated accordingly.